### PR TITLE
feat: bump Aurio to 4.2.0

### DIFF
--- a/AudioAlign/AudioAlign.csproj
+++ b/AudioAlign/AudioAlign.csproj
@@ -20,12 +20,12 @@
     <Resource Include="Resources\*.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Aurio" Version="4.1.0" />
-    <PackageReference Include="Aurio.FFmpeg" Version="4.1.0" />
-    <PackageReference Include="Aurio.PFFFT" Version="4.1.0" />
-    <PackageReference Include="Aurio.Soxr" Version="4.1.0" />
-    <PackageReference Include="Aurio.WaveControls" Version="4.1.0" />
-    <PackageReference Include="Aurio.Windows" Version="4.1.0" />
+    <PackageReference Include="Aurio" Version="4.2.0" />
+    <PackageReference Include="Aurio.FFmpeg" Version="4.2.0" />
+    <PackageReference Include="Aurio.PFFFT" Version="4.2.0" />
+    <PackageReference Include="Aurio.Soxr" Version="4.2.0" />
+    <PackageReference Include="Aurio.WaveControls" Version="4.2.0" />
+    <PackageReference Include="Aurio.Windows" Version="4.2.0" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.1.0" />
     <PackageReference Include="CSharpier.MsBuild" Version="0.26.4">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This update introduces multiple improvements related to the FFmpeg media access layer:
- Fixes for issues #14 and #15
- Improved media read performance
- Reduced memory use during proxy file creation
- Doubled proxy file size limit to 4GiB
- Reduced likelihood that a proxy file is necessary

See the release for detailed changes: https://github.com/protyposis/Aurio/releases/tag/v4.2.0.