### PR TITLE
fix: bump Aurio to 4.2.1

### DIFF
--- a/AudioAlign/AudioAlign.csproj
+++ b/AudioAlign/AudioAlign.csproj
@@ -20,12 +20,12 @@
     <Resource Include="Resources\*.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Aurio" Version="4.2.0" />
-    <PackageReference Include="Aurio.FFmpeg" Version="4.2.0" />
-    <PackageReference Include="Aurio.PFFFT" Version="4.2.0" />
-    <PackageReference Include="Aurio.Soxr" Version="4.2.0" />
-    <PackageReference Include="Aurio.WaveControls" Version="4.2.0" />
-    <PackageReference Include="Aurio.Windows" Version="4.2.0" />
+    <PackageReference Include="Aurio" Version="4.2.1" />
+    <PackageReference Include="Aurio.FFmpeg" Version="4.2.1" />
+    <PackageReference Include="Aurio.PFFFT" Version="4.2.1" />
+    <PackageReference Include="Aurio.Soxr" Version="4.2.1" />
+    <PackageReference Include="Aurio.WaveControls" Version="4.2.1" />
+    <PackageReference Include="Aurio.Windows" Version="4.2.1" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.1.0" />
     <PackageReference Include="CSharpier.MsBuild" Version="0.26.4">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This update introduces multiple fixes related to the FFmpeg media access layer:
- Add workaround for when FFmpeg seeks one frame too far (fixes issue https://github.com/protyposis/AudioAlign/issues/17)
- Fix crash when playing over end of certain FFmpeg-decoded files
- Create proxy file when first PTS cannot be determined with seek

See the release for detailed changes: https://github.com/protyposis/Aurio/releases/tag/v4.2.1.