### PR TITLE
feat: selective match flipping

### DIFF
--- a/AudioAlign/MatchingWindow.xaml.cs
+++ b/AudioAlign/MatchingWindow.xaml.cs
@@ -1108,10 +1108,19 @@ namespace AudioAlign
 
         private void FlipTracksButton_Click(object sender, RoutedEventArgs e)
         {
-            foreach (Match match in multiTrackViewer.Matches)
+            List<Match> matchesToFlip = new();
+
+            if (matchGrid.SelectedItems.Count > 0)
             {
-                match.SwapTracks();
+                matchesToFlip.AddRange(matchGrid.SelectedItems.Cast<Match>());
             }
+            else
+            {
+                matchesToFlip.AddRange(multiTrackViewer.Matches);
+            }
+
+            matchesToFlip.ForEach(m => m.SwapTracks());
+
             matchGrid.Items.Refresh();
         }
     }


### PR DESCRIPTION
The "Flip tracks" button in the matching window flipped the tracks of all matches. With this change, it only flips the selected matches when matches are selected, or all matches if none are selected.