### PR TITLE
fix: alignment graph plots offsets incorrectly

### DIFF
--- a/AudioAlign/AlignmentGraphWindow.xaml.cs
+++ b/AudioAlign/AlignmentGraphWindow.xaml.cs
@@ -57,6 +57,18 @@ namespace AudioAlign
             };
             matchPair
                 .Matches
+                .Select(m =>
+                {
+                    // Create copies to avoid unexpected swapping in match list
+                    var copy = new Match(m);
+
+                    if (copy.Track1 != matchPair.Track1)
+                    {
+                        copy.SwapTracks();
+                    }
+
+                    return copy;
+                })
                 .OrderBy(match => match.Track1Time)
                 .ToList()
                 .ForEach(


### PR DESCRIPTION
Fix plot offsets in the alignment graph for matches with mixed track orders by normalizing the track order. Fixes issue https://github.com/protyposis/AudioAlign/issues/19.